### PR TITLE
Changed OnTakeDamageKillCredit parameter type

### DIFF
--- a/packages/dota-lua-types/types/api.generated.d.ts
+++ b/packages/dota-lua-types/types/api.generated.d.ts
@@ -5260,7 +5260,7 @@ declare interface CDOTA_Modifier_Lua extends CDOTA_Buff {
      * @abstract
      * @both
      */
-    OnTakeDamageKillCredit?(event: ModifierInstanceEvent): void;
+    OnTakeDamageKillCredit?(event: ModifierAttackEvent): void;
     /**
      * @abstract
      * @both


### PR DESCRIPTION
Type from ModifierInstanceEvent to ModifierAttackEvent due to `target` existing in OnTakeDamageKillCredit parameter object, but is incorrectly typed and thus unable to use said `target` variable