### PR TITLE
fix: add shop item name field for ExecuteOrderFilterEvent payload

### DIFF
--- a/packages/dota-lua-types/types/api-types.generated.d.ts
+++ b/packages/dota-lua-types/types/api-types.generated.d.ts
@@ -269,6 +269,7 @@ declare interface ExecuteOrderFilterEvent {
     position_x: number;
     position_y: number;
     position_z: number;
+    shop_item_name?: string;
 }
 
 declare interface HealingFilterEvent {


### PR DESCRIPTION
shop_item_name field is lacked for `PURCHASE_ITEM` event