### PR TITLE
chore(css): add two types of attribute values for overflow

### DIFF
--- a/packages/panorama-types/types/css.d.ts
+++ b/packages/panorama-types/types/css.d.ts
@@ -527,7 +527,7 @@ interface VCSSStyleDeclaration {
      * overflow: squish squish; // squishes contents in horizontal and vertical directions
      * overflow: squish scroll; // scrolls contents in the Y direction
      */
-    overflow: 'squish' | 'clip' | 'scroll' | null;
+    overflow: 'squish' | 'clip' | 'scroll' | 'squish squish' | 'squish clip ' | 'squish scroll' | 'clip clip' | 'clip squish' | 'clip scroll' | 'scroll scroll' | 'scroll squish' | 'scroll clip' | null;
 
     padding: string | null;
     paddingBottom: string | null;


### PR DESCRIPTION
    /**
     * Specifies what to do with contents that overflow the available space for the panel. Possible values:
     * "squish" - Children are squished to fit within the panel's bounds if needed (default)
     * "clip" - Children maintain their desired size but their contents are clipped
     * "scroll" - Children maintain their desired size and a scrollbar is added to this panel
     *
     * Examples:
     * overflow: squish squish; // squishes contents in horizontal and vertical directions
     * overflow: squish scroll; // scrolls contents in the Y direction
 */  🦋❤️🥰